### PR TITLE
feat: language switching (new application based on Seablast for PHP/0.2.11)

### DIFF
--- a/.github/linters/phpcs.xml
+++ b/.github/linters/phpcs.xml
@@ -5,6 +5,6 @@
     <rule ref="PSR12" />
     <rule ref="PSR1.Classes.ClassDeclaration">
         <!-- Don't apply `each class is in a file by itself, and is in a namespace of at least one level: a top-level vendor name` to generated code -->
-        <exclude-pattern>db/migrations/*.php</exclude-pattern>
+        <exclude-pattern>conf/db/migrations/*.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   call-workflow:
-    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@v0.2.3
+    uses: WorkOfStan/seablast-actions/.github/workflows/overtrue-phplint.yml@v0.2.4

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -57,7 +57,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Invoke the PHPCS check and PHPCBF fix
-        # Use the latest commit in the main branch.
         uses: WorkOfStan/phpcs-fix@v1.0.2
         with:
           commit-changes: ${{ github.event_name != 'schedule' }}

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.3
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.4
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.2", "8.3", "8.4"]'
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
-        uses: WorkOfStan/prettier-fix@v1.1.4
+        uses: WorkOfStan/prettier-fix@v1.1.5
         with:
           commit-changes: ${{ github.event_name != 'schedule' }}
 
@@ -66,6 +66,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.3
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.4
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -15,7 +15,7 @@ on:
   schedule:
     # Run the workflow at 6:30 AM UTC on the 15th of every month
     - cron: "30 6 15 * *"
-    # TODO scheduled should not commit-changes automatically
+    # Scheduled runs do not commit-changes automatically to the same branch
 
 permissions:
   # only prettier-fix and phpcs-phpcbf need write permission, for others read is enough
@@ -44,9 +44,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
-        uses: WorkOfStan/prettier-fix@v1.1.3
+        uses: WorkOfStan/prettier-fix@v1.1.4
         with:
-          commit-changes: true
+          commit-changes: ${{ github.event_name != 'schedule' }}
 
   phpcs-phpcbf:
     needs: prettier-fix
@@ -58,9 +58,9 @@ jobs:
     steps:
       - name: Invoke the PHPCS check and PHPCBF fix
         # Use the latest commit in the main branch.
-        uses: WorkOfStan/phpcs-fix@v1.0.1
+        uses: WorkOfStan/phpcs-fix@v1.0.2
         with:
-          commit-changes: true
+          commit-changes: ${{ github.event_name != 'schedule' }}
           php-version: "8.2"
           stop-on-manual-fix: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 log/*
 cache/*
 !/log/.htaccess
-!/cache/.htaccess
 /.sass-cache/
 /.php_cs.cache
 /.php-cs-fixer.cache

--- a/.htaccess
+++ b/.htaccess
@@ -47,7 +47,7 @@ RedirectMatch 404 phpunit\.xml
 # hide files with these extensions
 RedirectMatch 404 \.md$
 RedirectMatch 404 \.neon$
-RedirectMatch 404 \.sass-cache$
 RedirectMatch 404 \.sh$
-RedirectMatch 404 \.stylelintignore$
 RedirectMatch 404 \.yml$
+# hide all the files in any directory that have no filename but only an extension (like .prettierignore)
+RedirectMatch 404 /(\.[^.]+)$

--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,4 @@
-# Friendly URL
+# Friendly URL and for RewriteRule below
 RewriteEngine on
 # In rare ocassion, when The original request, and the substitution, are underneath an Alias, see https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritebase
 #RewriteBase "/path/to/app/"

--- a/.htaccess
+++ b/.htaccess
@@ -34,9 +34,10 @@ RedirectMatch 404 \/cache\/
 RedirectMatch 404 \/conf\/
 RedirectMatch 404 \/log\/
 RedirectMatch 404 \/nbproject\/
-RedirectMatch 404 \/src\/
+# only src folder in the root is hidden from the web server access
+RedirectMatch 404 ^/src(/|$)
 RedirectMatch 404 \/temp\/
-RedirectMatch 404 \/Test\/
+RedirectMatch 404 \/tests\/
 RedirectMatch 404 \/views\/
 # hide these files
 RedirectMatch 404 composer\.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
+- PHPUnit tests folder renamed according to a common convention
+- Models moved to src folder for better compatibility
+
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bugfixes
+
+- only src folder in the root should be hidden from the web server access
+- Scheduled GitHub Action runs do not commit-changes automatically to the same branch
 
 ### `Security` in case of vulnerabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
+- local nav.latte for menu
+
 ### `Changed` for changes in existing functionality
 
 ### `Deprecated` for soon-to-be removed features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ feat: language switching (new application based on Seablast for PHP/0.2.11)
 - only src folder in the root should be hidden from the web server access
 - Scheduled GitHub Action runs do not commit-changes automatically to the same branch
 
-# Security
+### Security
 
 - return 404 and thus hide all the files in any directory that have no filename but only an extension (like .prettierignore)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- new application based on Seablast for PHP/0.2.9
+
 ### `Added` for new features
 
 ### `Changed` for changes in existing functionality
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+- return 404 and thus hide all the files in any directory that have no filename but only an extension (like .prettierignore)
 
 ## [0.1.3] - 2025-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- new application based on Seablast for PHP/0.2.9
-
 ### `Added` for new features
 
-- local nav.latte for menu
-- i18n module
-
 ### `Changed` for changes in existing functionality
-
-- PHPUnit tests folder renamed according to a common convention
-- Models moved to src folder for better compatibility
 
 ### `Deprecated` for soon-to-be removed features
 
@@ -25,10 +17,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed` for any bugfixes
 
+### `Security` in case of vulnerabilities
+
+## [0.1.4] - 2025-08-03
+
+feat: language switching (new application based on Seablast for PHP/0.2.11)
+
+### Added
+
+- local nav.latte for menu
+- i18n module
+- language switching by [Seablast\I18n](https://github.com/WorkOfStan/seablast-i18n) included.
+
+### Changed
+
+- PHPUnit tests folder renamed according to a common convention
+- Models moved to src folder for better compatibility
+
+### Fixed
+
 - only src folder in the root should be hidden from the web server access
 - Scheduled GitHub Action runs do not commit-changes automatically to the same branch
 
-### `Security` in case of vulnerabilities
+# Security
 
 - return 404 and thus hide all the files in any directory that have no filename but only an extension (like .prettierignore)
 
@@ -73,7 +84,8 @@ chore: GitHub Actions chaining
 - demonstrate API
 - demonstrate redirection
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-dist/compare/v0.1.3...HEAD?w=1
+[Unreleased]: https://github.com/WorkOfStan/seablast-dist/compare/v0.1.4...HEAD?w=1
+[0.1.4]: https://github.com/WorkOfStan/seablast-dist/compare/v0.1.3...v0.1.4?w=1
 [0.1.3]: https://github.com/WorkOfStan/seablast-dist/compare/v0.1.2...v0.1.3?w=1
 [0.1.2]: https://github.com/WorkOfStan/seablast-dist/compare/v0.1.1...v0.1.2?w=1
 [0.1.1]: https://github.com/WorkOfStan/seablast-dist/compare/v0.1...v0.1.1?w=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 - local nav.latte for menu
+- i18n module
 
 ### `Changed` for changes in existing functionality
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run [./blast.sh](./blast.sh) or [./vendor/seablast/seablast/blast.sh](https://gi
 - create `conf/phinx.local.php` based on [conf/phinx.dist.php](conf/phinx.dist.php) including the name of the database (and testing database) created above
 - create `conf/app.conf.local.php` based on [conf/app.conf.dist.php](conf/app.conf.dist.php) including the phinx environment to be used and change any settings you like. (OPTIONAL)
 
-Edit these two configuration files; then re-run assemble.sh
+Edit these two configuration files; then re-run blast.sh
 
 Note: the current configuration is in the `conf/phinx.local.php` so that it is automatically NOT commited to Git
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Note: the current configuration is in the `conf/phinx.local.php` so that it is a
 
 If PHPStan reports `Constant APP_DIR not found.` error, just uncomment lines in [conf/phpstan.webmozart-assert.neon](conf/phpstan.webmozart-assert.neon).
 
+```sh
+# For all the deployment and development options, run
+./vendor/seablast/seablast/blast.sh -?
+```
+
 ### Folders, where web can write
 
 - cache and log (and also e.g. app specific uploads)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create database with `Collation=utf8_general_ci` or rather `utf8mb3_general_ci` 
 
 Before starting to develop on this boilerplate, rename the namespace according to your app.
 
-Run [./blast.sh](./blast.sh) or [./vendor/seablast/seablast/blast.sh](https://github.com/WorkOfStan/seablast/blob/v0.2.9/blast.sh) to
+Run [./blast.sh](./blast.sh) or [./vendor/seablast/seablast/blast.sh](https://github.com/WorkOfStan/seablast/blob/v0.2.10.1/blast.sh) to
 
 - create `conf/phinx.local.php` based on [conf/phinx.dist.php](conf/phinx.dist.php) including the name of the database (and testing database) created above
 - create `conf/app.conf.local.php` based on [conf/app.conf.dist.php](conf/app.conf.dist.php) including the phinx environment to be used and change any settings you like. (OPTIONAL)
@@ -55,7 +55,7 @@ If PHPStan reports `Constant APP_DIR not found.` error, just uncomment lines in 
 | --------- | ------------------------------------------------------------------------------------------------- |
 | .github/  | Automations                                                                                       |
 | assets/   | Frontend assets. When dealing with numerous assets, categorize them into specific subdirectories. |
-| cache/    | Latte cache                                                                                       |
+| cache/    | Latte cache (deployed by [blast.sh](blast.sh))                                                    |
 | conf/     | All configuration files: Seablast app, PHPStan, phinx                                             |
 | log/      | All kind of logs                                                                                  |
 | src/      | Classes with respecitve subfolders src/Data, src/Exceptions, src/Models...                        |

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ All planned changes to this project are documented in this file.
 ## Demo
 
 - 231221, use SB_GET_ARGUMENT_ID and SB_GET_ARGUMENT_CODE to demonstrate GET parameter usage
-- 231229, adapt menu to display the links from README.md examples
+- 231229, adapt menu to display the links from README.md examples section
 - 240112, /api/error using \Seablast\Seablast\Api\ApiErrorModel
 - 241205, add some full Model with `public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)`
 
@@ -13,7 +13,3 @@ All planned changes to this project are documented in this file.
 
 - 231207, CSRF token
 - 241205, add Seablast/Auth
-
-## Governance
-
-- 231130, move phinx and pagestructure to sb composer.json

--- a/blast.sh
+++ b/blast.sh
@@ -49,12 +49,12 @@ setup_environment() {
     done
 
     # Create local config if not present but the dist template is available, if newly created, then stop the script so that the admin may adapt the newly created config
-    [[ ! -f "conf/app.conf.local.php" && -f "conf/app.conf.dist.php" ]] && cp -p conf/app.conf.dist.php conf/app.conf.local.php && warning "Check/modify the newly created conf/app.conf.local.php"  && exit 0
+    [[ ! -f "conf/app.conf.local.php" && -f "conf/app.conf.dist.php" ]] && cp -p conf/app.conf.dist.php conf/app.conf.local.php && display_warning "Check/modify the newly created conf/app.conf.local.php"  && exit 0
 
     # conf/phinx.local.php or at least conf/phinx.dist.php is required
     if [[ ! -f "conf/phinx.local.php" ]]; then
-        [[ ! -f "conf/phinx.dist.php" ]] && warning "phinx config is required for a Seablast app" && exit 0
-        cp -p conf/phinx.dist.php conf/phinx.local.php && warning "Check/modify the newly created conf/phinx.local.php"
+        [[ ! -f "conf/phinx.dist.php" ]] && display_warning "phinx config is required for a Seablast app" && exit 0
+        cp -p conf/phinx.dist.php conf/phinx.local.php && display_warning "Check/modify the newly created conf/phinx.local.php"
         exit 0
     fi
 }

--- a/blast.sh
+++ b/blast.sh
@@ -157,8 +157,8 @@ fi
 case "$1" in
     main)
         printf "Switches your working tree to the specified branch: main. Git will then fetch from origin (showing you a verbose progress report), bringing in all branches and tags, deleting any remote-tracking branches that have been removed on the server, and then merge (not rebase) the corresponding remote branch into your current branch.\n"
-        read -p "Continue? [y/N] " -n1; echo
-        [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+        read -r -n1 -p "Continue? [y/N] " reply; echo
+        [[ $reply =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
         back_to_main
         ;;
     phpstan)

--- a/blast.sh
+++ b/blast.sh
@@ -128,7 +128,7 @@ self_update() {
             cp "$update_file" "$0"
             display_header "Self-update successful: Updated to the newer version from $update_file"
         else
-            display_warning "Self-update: Update file found but it is not newer than the current version."
+            display_warning "Self-update: Update file found, but it is not newer than the current version."
         fi
     else
         display_warning "Self-update: Update file not found at $update_file"
@@ -155,16 +155,19 @@ fi
 
 # Handle command-line parameters
 case "$1" in
-    main) 
+    main)
+        printf "Switches your working tree to the specified branch: main. Git will then fetch from origin (showing you a verbose progress report), bringing in all branches and tags, deleting any remote-tracking branches that have been removed on the server, and then merge (not rebase) the corresponding remote branch into your current branch.\n"
+        read -p "Continue? [y/N] " -n1; echo
+        [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
         back_to_main
         ;;
-    phpstan) 
+    phpstan)
         run_phpstan "--memory-limit 350M"
         ;;
-    phpstan-pro) 
+    phpstan-pro)
         run_phpstan "--memory-limit 350M --pro"
         ;;
-    phpstan-remove) 
+    phpstan-remove)
         phpstan_remove
         ;;
     self-update)

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "repositories": [
     {
       "type": "vcs",
-      "url":  "https://github.com/WorkOfStan/seablast-i18n"
+      "url": "https://github.com/WorkOfStan/seablast-i18n"
     }
   ],
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -2,18 +2,12 @@
   "name": "seablast/dist",
   "description": "Distribution of Seablast for PHP - a seed application",
   "type": "project",
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/WorkOfStan/seablast-i18n"
-    }
-  ],
   "require": {
     "php": ">=7.2.5 <8.0 || >=8.2.0 <8.5",
     "guzzlehttp/guzzle": "^7.8",
     "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5",
-    "seablast/i18n": "dev-feature/fix-cookie-scope",
-    "seablast/seablast": "dev-feature/i18n"
+    "seablast/i18n": "^0.1",
+    "seablast/seablast": "^0.2.11"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11 || ^12"

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,18 @@
   "name": "seablast/dist",
   "description": "Distribution of Seablast for PHP - a seed application",
   "type": "project",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url":  "https://github.com/WorkOfStan/seablast-i18n"
+    }
+  ],
   "require": {
-    "php": "^7.2.5 || ^8.2.0",
+    "php": ">=7.2.5 <8.0 || >=8.2.0 <8.5",
     "guzzlehttp/guzzle": "^7.8",
     "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5",
-    "seablast/seablast": "dev-feature/nav-latte"
+    "seablast/i18n": "dev-feature/init",
+    "seablast/seablast": "^0.2.10.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11 || ^12"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "php": "^7.2.5 || ^8.2.0",
     "guzzlehttp/guzzle": "^7.8",
     "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5",
-    "seablast/seablast": "^0.2.9"
+    "seablast/seablast": "dev-feature/nav-latte"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11 || ^12"

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "php": ">=7.2.5 <8.0 || >=8.2.0 <8.5",
     "guzzlehttp/guzzle": "^7.8",
     "robmorgan/phinx": "^0.12.13 || ^0.13.4 || ^0.14.0 || ^0.15.5 || ^0.16.5",
-    "seablast/i18n": "dev-feature/init",
-    "seablast/seablast": "^0.2.10.1"
+    "seablast/i18n": "dev-feature/fix-cookie-scope",
+    "seablast/seablast": "dev-feature/i18n"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4 || ^9 || ^10 || ^11 || ^12"

--- a/conf/app.conf.dist.php
+++ b/conf/app.conf.dist.php
@@ -15,10 +15,11 @@ use Seablast\Seablast\SeablastConstant;
 
 return static function (SeablastConfiguration $SBConfig): void {
     $SBConfig->flag
-        //->deactivate(SeablastConstant::FLAG_WEB_RUNNING)
+        //->deactivate(SeablastConstant::FLAG_WEB_RUNNING) // doesn't have an effect on localhost
         //->activate(SeablastConstant::FLAG_DEBUG_JSON) // JSON would be displayed directly with Tracy
         ->activate(SeablastConstant::ADMIN_MAIL_ENABLED) // live on server
         ->activate(SeablastConstant::USER_MAIL_ENABLED)  // live on server
+        //->deactivate(I18nConstant::FLAG_SHOW_LANGUAGE_SELECTOR)
         ;
     $SBConfig
         ->setArrayString(SeablastConstant::DEBUG_IP_LIST, [

--- a/conf/app.conf.php
+++ b/conf/app.conf.php
@@ -41,6 +41,22 @@ return static function (SeablastConfiguration $SBConfig): void {
         )
         ->setArrayArrayString(
             SeablastConstant::APP_MAPPING,
+            '/blog-e', // page slug, i.e. URL representation
+            [
+                'template' => 'blog-editable', // template used by the View component
+                'model' => '\Seablast\Distribution\Models\BlogModel',
+            ]
+        )
+        ->setArrayArrayString(
+            SeablastConstant::APP_MAPPING,
+            '/blog-r', // page slug, i.e. URL representation
+            [
+                'template' => 'blog-readonly', // template used by the View component
+                'model' => '\Seablast\Distribution\Models\BlogModel',
+            ]
+        )
+        ->setArrayArrayString(
+            SeablastConstant::APP_MAPPING,
             '/item', // page slug, i.e. URL representation
             [
                 'template' => 'item', // template used by the View component

--- a/conf/db/migrations/20250803081249_first_blog_posts.php
+++ b/conf/db/migrations/20250803081249_first_blog_posts.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class FirstBlogPosts extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $itemTypes = [
+            ['id' => 1, 'name' => 'blogpost'],
+        ];
+
+        //$itemTypesTable =
+        $this->table('localised_item_types')->insert($itemTypes)->saveData();
+
+        // phpcs:disable Generic.Files.LineLength
+        $blogPosts = [
+            ['item_id' => 1, 'language' => 'cs', 'title' => 'Co je Seablast for PHP?',
+                'content' => 'Tento minimalistický MVC framework přidaný kompozitorem vám pomůže vytvořit komplexní, ale snadno udržovatelnou webovou aplikaci POUZE pomocí konfigurace:
+a) nakonfigurujete trasy pro řadič,
+b) přidáte modely pro funkčnost aplikace,
+c) volitelně upravíte šablony zobrazení.
+Framework se postará o logy, databázi, více jazyků, uživatelsky přívětivé chyby HTTP a přátelské URL.',
+                'item_type_id' => 1,],
+            ['item_id' => 1, 'language' => 'en', 'title' => 'What is Seablast for PHP?',
+                'content' => '
+            This minimalist MVC framework added by composer helps you to create a complex, yet easy to maintain, web application by configuration ONLY:
+a) you configure routes for controller,
+b) add models for the app business functionality,
+c) optionally modify view templates.
+The framework takes care of logs, database, multiple languages, user friendly HTTP errors, friendly URL.
+            ',
+                'item_type_id' => 1,],
+            ['item_id' => 2, 'language' => 'cs', 'title' => 'Lorem 2',
+                'content' => 'Ipsum 2',
+                'item_type_id' => 1,],
+            ['item_id' => 3, 'language' => 'cs', 'title' => 'Lorem 3',
+                'content' => 'Ipsum 3',
+                'item_type_id' => 1,],
+            ['item_id' => 4, 'language' => 'cs', 'title' => 'Lorem 4', 'content' => 'Ipsum 4', 'item_type_id' => 1, 'active' => 0],
+            ['item_id' => 5, 'language' => 'cs', 'title' => 'Lorem 5', 'content' => 'Ipsum 5', 'item_type_id' => 1, 'active' => 0],
+            ['item_id' => 6, 'language' => 'cs', 'title' => 'Lorem 6', 'content' => 'Ipsum 6', 'item_type_id' => 1, 'active' => 0],
+            ['item_id' => 7, 'language' => 'cs', 'title' => 'Lorem 7', 'content' => 'Ipsum 7', 'item_type_id' => 1, 'active' => 0],
+            ['item_id' => 8, 'language' => 'cs', 'title' => 'Lorem 8', 'content' => 'Ipsum 8', 'item_type_id' => 1, 'active' => 0],
+            ['item_id' => 9, 'language' => 'cs', 'title' => 'Lorem 9', 'content' => 'Ipsum 9', 'item_type_id' => 1, 'active' => 0],
+            ['item_id' => 10, 'language' => 'cs', 'title' => 'Lorem 10', 'content' => 'Ipsum 10', 'item_type_id' => 1, 'active' => 0],
+        ];
+        // phpcs:enable
+        $this->table('localised_items')->insert($blogPosts)->saveData();
+    }
+}

--- a/conf/phinx.dist.php
+++ b/conf/phinx.dist.php
@@ -9,7 +9,7 @@ return
             '%%PHINX_CONFIG_DIR%%/db/migrations',
             // comment out following lines if phinx create selection gets stuck
             //'%%PHINX_CONFIG_DIR%%/../vendor/seablast/auth/conf/db/migrations',
-            //'%%PHINX_CONFIG_DIR%%/../vendor/seablast/i18n/conf/db/migrations',
+            '%%PHINX_CONFIG_DIR%%/../vendor/seablast/i18n/conf/db/migrations',
         ],
         'seeds' => '%%PHINX_CONFIG_DIR%%/db/seeds'
     ],

--- a/conf/phinx.dist.php
+++ b/conf/phinx.dist.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 return
 [
     'paths' => [
-        'migrations' => '%%PHINX_CONFIG_DIR%%/db/migrations',
+        'migrations' => [
+            '%%PHINX_CONFIG_DIR%%/db/migrations',
+            // comment out following lines if phinx create selection gets stuck
+            //'%%PHINX_CONFIG_DIR%%/../vendor/seablast/auth/conf/db/migrations',
+            //'%%PHINX_CONFIG_DIR%%/../vendor/seablast/i18n/conf/db/migrations',
+        ],
         'seeds' => '%%PHINX_CONFIG_DIR%%/db/seeds'
     ],
     'environments' => [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
     stopOnFailure="false"> 
     <testsuites> 
         <testsuite name="Application Test Suite"> 
-            <directory>./Test/</directory> 
+            <directory>./tests/</directory> 
         </testsuite> 
     </testsuites> 
 </phpunit>

--- a/src/Models/BlogModel.php
+++ b/src/Models/BlogModel.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Distribution\Models;
+
+use Seablast\I18n\Models\FetchLocalisedItemsModel;
+use Seablast\Seablast\SeablastConfiguration;
+use Seablast\Seablast\Superglobals;
+
+/**
+ * Retrieve items from database
+ */
+class BlogModel extends FetchLocalisedItemsModel
+{
+    use \Nette\SmartObject;
+
+    /**
+     * @param SeablastConfiguration $configuration
+     * @param Superglobals $superglobals
+     */
+    public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
+    {
+        $this->itemTypeId = 1; // Blog type ID // TODO create actually blog item_type
+        $this->titlePrefix = "Seablast Distribution - ";
+        $this->titleSuffix = "Blog";
+        $configuration->mysqli(); // dbms prefix set up even if Seablast\Auth is not present and thus it's not
+        //already set up in SeablastController: `$this->identity = new $identityManager($this->configuration->mysqli());
+        // TODO check if there will be user set as in other pages?
+        parent::__construct($configuration, $superglobals);
+    }
+}

--- a/src/Models/RedirModel.php
+++ b/src/Models/RedirModel.php
@@ -16,10 +16,11 @@ class RedirModel // implements SeablastModelInterface
     public function knowledge(): stdClass
     {
         // typecasting array to stdClass works since PHP4
-        $result = (object) ['httpCode' => 302, 'redirection' => (object) [
-            'url' => // SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL
+        $result = (object) ['httpCode' => 302, 'redirectionUrl' => //(object) [
+            //'url' => // SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL
             './kontakt'
-            ]];
+            //]
+            ];
         return $result;
     }
 }

--- a/src/Models/RedirModel.php
+++ b/src/Models/RedirModel.php
@@ -6,17 +6,9 @@ namespace Seablast\Distribution\Models;
 
 use stdClass;
 
-//use Tracy\Debugger;
-//use Webmozart\Assert\Assert;
-
-class RedirModel
+class RedirModel // implements SeablastModelInterface
 {
     use \Nette\SmartObject;
-
-    public function __construct()
-    {
-        //
-    }
 
     /**
      * @return stdClass
@@ -24,7 +16,10 @@ class RedirModel
     public function knowledge(): stdClass
     {
         // typecasting array to stdClass works since PHP4
-        $result = (object) ['httpCode' => 302, 'redirection' => (object) ['url' => './kontakt']];
+        $result = (object) ['httpCode' => 302, 'redirection' => (object) [
+            'url' => // SeablastConstant::SB_APP_ROOT_ABSOLUTE_URL
+            './kontakt'
+            ]];
         return $result;
     }
 }

--- a/views/blog-editable.latte
+++ b/views/blog-editable.latte
@@ -1,0 +1,35 @@
+{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}
+{block mainblock}
+<h1>
+    {ifset $itemId}
+        <a href="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/blog-e">Blog (editable)</a>
+    {else}
+        Blog
+    {/ifset}
+</h1>
+
+{foreach $items as $item}
+    <article class="post">
+        {* Check if $itemId is set to decide if we have multiple posts - If we have an “id” parameter, we’re in single‐post mode *}
+        {ifset $itemId}
+            {* single‐item mode: editable fields for admins *}
+            <h2 class="editable"
+                {if $configuration->flag->status('SB:USER_IS_AUTHENTICATED') && in_array($configuration->getInt('SB:USER_ROLE_ID'), [1,2])}
+                    data-api-parameter="val" data-api="api/poseidon/?t=localised_items&key=title&id={$item['item_id']}"
+                {/if}
+                >{$item['title']}</h2>
+            {*<p class="post-date">Created at: {$item['created_at']}</p>*}
+            <div class="post-content editable"
+                 {if $configuration->flag->status('SB:USER_IS_AUTHENTICATED') && in_array($configuration->getInt('SB:USER_ROLE_ID'), [1,2])}
+                     data-api-parameter="val" data-api="api/poseidon/?t=localised_items&key=content&id={$item['item_id']}"
+                 {/if}
+                 >{$item['content']|breakLines}</div>
+        {else}
+            {* listing mode: links into each item TODO paging *}
+            <h2><a href="?id={$item['item_id']}">{$item['title']}</a></h2>
+            {*<p class="post-date">Created at: {$item['created_at']}</p>*}
+            <div class="post-content">{$item['content']|breakLines}...</div>
+        {/ifset}
+    </article>
+{/foreach}
+{/block}

--- a/views/blog-readonly.latte
+++ b/views/blog-readonly.latte
@@ -1,0 +1,27 @@
+{layout '../vendor/seablast/seablast/views/BlueprintWeb.latte'}
+{block mainblock}
+<h1>
+    {ifset $itemId}
+        <a href="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/blog-r">Blog (read-only)</a>
+    {else}
+        Blog
+    {/ifset}
+</h1>
+
+{foreach $items as $item}
+    <article class="post">
+        {* Check if $itemId is set to decide if we have multiple posts - If we have an “id” parameter, we’re in single‐post mode *}
+        {ifset $itemId}
+            {* single‐item mode: editable fields for admins *}
+            <h2>{$item['title']}</h2>
+            {*<p class="post-date">Created at: {$item['created_at']}</p>*}
+            <div class="post-content">{$item['content']|breakLines}</div>
+        {else}
+            {* listing mode: links into each item TODO paging *}
+            <h2><a href="?id={$item['item_id']}">{$item['title']}</a></h2>
+            {*<p class="post-date">Created at: {$item['created_at']}</p>*}
+            <div class="post-content">{$item['content']|breakLines}...</div>
+        {/ifset}
+    </article>
+{/foreach}
+{/block}

--- a/views/nav.latte
+++ b/views/nav.latte
@@ -6,5 +6,7 @@
                     <li><a href="#">About</a></li>
                     <li><a href="#">Services</a></li>
                     <li><a href="#">Contact</a></li>
-                    <li><a href="#">TestNav</a></li>
+                    <li><a href="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/blog-e">Blog (editable)</a></li>
+                    <li><a href="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/blog-r">Blog (read-only)</a></li>
+                    <li n:if="$configuration->flag->status('I18n:SHOW_LANGUAGE_SELECTOR')">{include '../vendor/seablast/i18n/views/uls.menu.latte'}</li>
                 </ul>

--- a/views/nav.latte
+++ b/views/nav.latte
@@ -1,0 +1,9 @@
+                {* TODO JavaScript to toggle menu *}
+                <!-- Hamburger menu for mobile -->
+                <div id="hamburger-menu">☰</div>
+                <ul id="menu">
+                    <li><a href="#">HOME DIST</a></li>
+                    <li><a href="#">About</a></li>
+                    <li><a href="#">Services</a></li>
+                    <li><a href="#">Contact</a></li>
+                </ul>

--- a/views/nav.latte
+++ b/views/nav.latte
@@ -6,4 +6,5 @@
                     <li><a href="#">About</a></li>
                     <li><a href="#">Services</a></li>
                     <li><a href="#">Contact</a></li>
+                    <li><a href="#">TestNav</a></li>
                 </ul>


### PR DESCRIPTION
### Added

- local nav.latte for menu
- i18n module
- language switching by [Seablast\I18n](https://github.com/WorkOfStan/seablast-i18n) included.

### Changed

- PHPUnit tests folder renamed according to a common convention
- Models moved to src folder for better compatibility

### Fixed

- only src folder in the root should be hidden from the web server access
- Scheduled GitHub Action runs do not commit-changes automatically to the same branch

### Security

- return 404 and thus hide all the files in any directory that have no filename but only an extension (like .prettierignore)
